### PR TITLE
Fix deprecated Playwright GitHub Action causing e2e test failures

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -152,9 +152,9 @@ jobs:
           echo "Port forwarding is ready"
 
       - name: Install Playwright
-        uses: microsoft/playwright-github-action@v1
-        with:
-          browsers: chromium
+        run: |
+          # Install Playwright browsers and dependencies using Python Playwright
+          playwright install --with-deps chromium
 
       - name: Run Playwright tests
         run: pytest tests/test_app_playwright.py --browser chromium --timeout=300


### PR DESCRIPTION
## Summary
Fix the e2e test failures caused by deprecated `microsoft/playwright-github-action@v1` that was failing with dependency installation errors.

## Problem
The GitHub Actions workflow was failing at the Playwright installation step with:
```
Cannot install dependencies for this linux distribution\!
```

The `microsoft/playwright-github-action@v1` is deprecated and the error was coming from: https://github.com/jessegoodier/logpilot/actions/runs/15548643414/job/43774866118

## Solution
- Replace the deprecated GitHub Action with native `playwright install --with-deps chromium`
- Use the Python Playwright installation method which is more reliable
- This is the recommended approach per Playwright documentation

## Testing
- ✅ Tested locally: `playwright install --with-deps chromium` works correctly
- ✅ Confirmed test collection works: `pytest --collect-only tests/test_app_playwright.py`
- ✅ Follows our new git safety rules (fresh branch from main, no merged PR)

## Changes
```diff
- name: Install Playwright
- uses: microsoft/playwright-github-action@v1
- with:
-   browsers: chromium
+ name: Install Playwright
+ run: |
+   # Install Playwright browsers and dependencies using Python Playwright
+   playwright install --with-deps chromium
```

This should resolve the e2e test failures and get the CI pipeline working again.

🤖 Generated with [Claude Code](https://claude.ai/code)