### PR TITLE
Remove invalid pytest --timeout argument causing test failures

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -157,7 +157,7 @@ jobs:
           playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: pytest tests/test_app_playwright.py --browser chromium --timeout=300
+        run: pytest tests/test_app_playwright.py --browser chromium
         env:
           PYTHONPATH: .
           TEST_BASE_URL: "http://localhost:5001"


### PR DESCRIPTION
## Summary
Fix the pytest command in the e2e workflow by removing the invalid `--timeout=300` argument that was causing test failures.

## Problem
The pytest command was failing with:
```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --timeout=300
```

The `--timeout` argument is not a standard pytest option and requires the `pytest-timeout` plugin to be installed, which is not part of our dependencies.

## Solution
- Remove the `--timeout=300` argument from the pytest command
- Playwright tests have their own timeout mechanisms built-in
- Default pytest behavior is sufficient for these e2e tests

## Testing
- ✅ Tested locally: `pytest tests/test_app_playwright.py --browser chromium --collect-only` works
- ✅ Verified `--browser chromium` option is available from pytest-playwright plugin
- ✅ Followed git safety rules (fresh branch from main, no merged PR)

## Changes
```diff
- run: pytest tests/test_app_playwright.py --browser chromium --timeout=300
+ run: pytest tests/test_app_playwright.py --browser chromium
```

This should resolve the pytest argument error and allow the e2e tests to run successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)