### PR TITLE
Fix GitHub Actions release workflow by updating placeholder versions

### DIFF
--- a/.github/bumpversion.cfg
+++ b/.github/bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.0-dev
+current_version = 0.3.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[a-z]+))?
 serialize =
 	{major}.{minor}.{patch}-{release}

--- a/charts/logpilot/Chart.yaml
+++ b/charts/logpilot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: logpilot
 description: A Helm chart for logPilot
 type: application
-version: 0.0.0-dev
-appVersion: "0.0.0-dev"
+version: 0.3.4
+appVersion: "0.3.4"
 keywords:
   - kubernetes
   - logs

--- a/charts/logpilot/pyproject.toml
+++ b/charts/logpilot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logPilot"
-version = "0.0.0-dev"
+version = "0.3.4"
 description = "A simple Kubernetes log viewer web app"
 requires-python = ">=3.12"
 dependencies = [

--- a/charts/logpilot/src/__init__.py
+++ b/charts/logpilot/src/__init__.py
@@ -2,4 +2,4 @@
 logPilot - A web-based Kubernetes log viewer
 """
 
-__version__ = "0.0.0-dev"
+__version__ = "0.3.4"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - containerPort: 5001
         env:
         - name: APP_VERSION
-          value: "0.0.0-dev" # APP_VERSION
+          value: "0.3.4" # APP_VERSION
         - name: RETAIN_ALL_POD_LOGS
           value: "true"
         - name: MAX_LOG_RETENTION_MINUTES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logPilot"
-version = "0.0.0-dev"
+version = "0.3.4"
 description = "A simple Kubernetes log viewer web app"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 logPilot - A web-based Kubernetes log viewer
 """
 
-__version__ = "0.0.0-dev"
+__version__ = "0.3.4"


### PR DESCRIPTION
## Summary
• Update all version references from "0.0.0-dev" to current release "0.3.4"
• Fix bumpversion configuration to use correct current_version baseline
• Resolve GitHub Actions release workflow failures

## Test plan
- [x] Verify all version files contain "0.3.4" instead of "0.0.0-dev" 
- [x] Confirm bumpversion.cfg current_version matches latest release
- [ ] Test that next release workflow runs successfully with these changes
- [ ] Validate that bumpversion can now find and update version strings correctly

🤖 Generated with [Claude Code](https://claude.ai/code)