### PR TITLE
Add case-sensitive search and full log search functionality

### DIFF
--- a/.github/scripts/update_helm_bumper.py
+++ b/.github/scripts/update_helm_bumper.py
@@ -1,37 +1,39 @@
-from ruamel.yaml import YAML
-import requests
 import sys
+
+import requests
+from ruamel.yaml import YAML
+
 
 def get_version_branches():
     # Get version branches from github api
-    response = requests.get('https://api.github.com/repos/jessegoodier/logpilot/branches')
-    return [branch['name'] for branch in response.json() if branch['name'].startswith('v')]
+    response = requests.get("https://api.github.com/repos/jessegoodier/logpilot/branches")
+    return [branch["name"] for branch in response.json() if branch["name"].startswith("v")]
 
 
 def update_workflow_file():
     yaml = YAML()
     yaml.preserve_quotes = True
     yaml.indent(mapping=2, sequence=4, offset=2)
-    with open('.github/workflows/helm-bumper.yml', 'r') as f:
+    with open(".github/workflows/helm-bumper.yml", "r") as f:
         workflow = yaml.load(f)
 
     # Get version branches
     version_branches = get_version_branches()
     # add main to the list of version branches
-    version_branches.append('main')
+    version_branches.append("main")
     # Navigate to the options and default fields
     try:
-        branch_input = workflow['on']['workflow_dispatch']['inputs']['branch']
-        branch_input['options'] = version_branches
-        branch_input['default'] = version_branches[0] if version_branches else 'main'
+        branch_input = workflow["on"]["workflow_dispatch"]["inputs"]["branch"]
+        branch_input["options"] = version_branches
+        branch_input["default"] = version_branches[0] if version_branches else "main"
     except Exception as e:
         print(f"Error updating YAML: {e}")
         sys.exit(1)
 
     # Write the updated workflow file
-    with open('.github/workflows/helm-bumper.yml', 'w') as f:
+    with open(".github/workflows/helm-bumper.yml", "w") as f:
         yaml.dump(workflow, f)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     update_workflow_file()

--- a/charts/README.md
+++ b/charts/README.md
@@ -6,29 +6,16 @@ Give direct log access to your software engineers to see the logs without giving
 
 This application is designed to only monitor logs of pods in the namespace it is deployed to.
 
+More information about the application can be found in the [project readme](https://github.com/jessegoodier/logpilot).
+
 ## Installation
 
-### Install from web
+Install the latest version from the web in your namespace (using `kube-system` as an example):
 
-The name of the chart is logpilot. The recommended release name is `<namespace>-log`
-
-If you use this naming, the command:
 ```sh
-helm install kube-system-log \
+helm install logpilot \
   --repo https://jessegoodier.github.io/logpilot logpilot \
   -n kube-system
-```
-
-Will result in a Deployment named:
-
-`kube-system-log-logpilot`
-
-Install using the default values:
-
-```sh
-# Install with default settings
-helm install NAMESPACE-log \
-  --repo https://jessegoodier.github.io/logpilot logpilot
 ```
 
 Disable retaining logs of pods that have been terminated:
@@ -54,43 +41,43 @@ helm install logpilot \
 
 The following table lists the configurable parameters and their default values:
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `auth.apiKey` | API authentication key (set to "no-key" or empty to disable) | `"no-key"` |
-| `auth.existingSecret` | Use existing secret for API key | `""` |
-| `auth.existingSecretKey` | Key in existing secret containing API key | `"api-key"` |
-| `previousPodLogs.enabled` | Enable/disable log archival functionality | `true` |
-| `previousPodLogs.retentionMinutes` | Log retention period in minutes (7 days default) | `10080` |
-| `previousPodLogs.allowPurge` | Allow purging of previous pod logs | `true` |
-| `storage.type` | Storage type: "emptyDir" or "persistentVolume" | `emptyDir` |
-| `storage.persistentVolume.size` | PVC size when using persistent storage | `5Gi` |
-| `storage.persistentVolume.storageClass` | Storage class for PVC | `""` |
-| `storage.persistentVolume.accessModes` | Access modes for PVC | `["ReadWriteOnce"]` |
-| `replicaCount` | Number of replicas | `1` |
-| `image.repository` | Container image repository | `python` |
-| `image.tag` | Container image tag | `"3.13-slim"` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `ingress.enabled` | Enable ingress | `false` |
-| `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.ingressClassName` | Ingress class name | `""` |
-| `ingress.hosts` | Ingress hosts configuration | See values.yaml |
-| `ingress.tls` | Ingress TLS configuration | See values.yaml |
-| `service.type` | Service type | `ClusterIP` |
-| `service.port` | Service port | `5001` |
-| `resources.requests.memory` | Memory request | `"128Mi"` |
-| `resources.requests.cpu` | CPU request | `"100m"` |
-| `resources.limits.memory` | Memory limit | `"256Mi"` |
-| `resources.limits.cpu` | CPU limit | `"1500m"` |
-| `rbac.create` | Create RBAC resources | `true` |
-| `serviceAccount.create` | Create service account | `true` |
-| `serviceAccount.annotations` | Service account annotations | `{}` |
-| `serviceAccount.name` | Service account name | `""` |
+| Parameter                               | Description                                                  | Default             |
+| --------------------------------------- | ------------------------------------------------------------ | ------------------- |
+| `auth.apiKey`                           | API authentication key (set to "no-key" or empty to disable) | `"no-key"`          |
+| `auth.existingSecret`                   | Use existing secret for API key                              | `""`                |
+| `auth.existingSecretKey`                | Key in existing secret containing API key                    | `"api-key"`         |
+| `previousPodLogs.enabled`               | Enable/disable log archival functionality                    | `true`              |
+| `previousPodLogs.retentionMinutes`      | Log retention period in minutes (7 days default)             | `10080`             |
+| `previousPodLogs.allowPurge`            | Allow purging of previous pod logs                           | `true`              |
+| `storage.type`                          | Storage type: "emptyDir" or "persistentVolume"               | `emptyDir`          |
+| `storage.persistentVolume.size`         | PVC size when using persistent storage                       | `5Gi`               |
+| `storage.persistentVolume.storageClass` | Storage class for PVC                                        | `""`                |
+| `storage.persistentVolume.accessModes`  | Access modes for PVC                                         | `["ReadWriteOnce"]` |
+| `replicaCount`                          | Number of replicas                                           | `1`                 |
+| `image.repository`                      | Container image repository                                   | `python`            |
+| `image.tag`                             | Container image tag                                          | `"3.13-slim"`       |
+| `image.pullPolicy`                      | Image pull policy                                            | `IfNotPresent`      |
+| `ingress.enabled`                       | Enable ingress                                               | `false`             |
+| `ingress.annotations`                   | Ingress annotations                                          | `{}`                |
+| `ingress.ingressClassName`              | Ingress class name                                           | `""`                |
+| `ingress.hosts`                         | Ingress hosts configuration                                  | See values.yaml     |
+| `ingress.tls`                           | Ingress TLS configuration                                    | See values.yaml     |
+| `service.type`                          | Service type                                                 | `ClusterIP`         |
+| `service.port`                          | Service port                                                 | `5001`              |
+| `resources.requests.memory`             | Memory request                                               | `"128Mi"`           |
+| `resources.requests.cpu`                | CPU request                                                  | `"100m"`            |
+| `resources.limits.memory`               | Memory limit                                                 | `"256Mi"`           |
+| `resources.limits.cpu`                  | CPU limit                                                    | `"1500m"`           |
+| `rbac.create`                           | Create RBAC resources                                        | `true`              |
+| `serviceAccount.create`                 | Create service account                                       | `true`              |
+| `serviceAccount.annotations`            | Service account annotations                                  | `{}`                |
+| `serviceAccount.name`                   | Service account name                                         | `""`                |
 
 ## Examples
 
 ### Custom Values File
 
-Create a `custom-values.yaml` file:
+Create a `helmValues-logpilot.yaml` file:
 
 ```yaml
 auth:
@@ -134,7 +121,7 @@ Then install with:
 ```bash
 helm install logpilot \
   --repo https://jessegoodier.github.io/logpilot logpilot \
-  -f custom-values.yaml
+  -f helmValues-logpilot.yaml
 ```
 
 ## Features
@@ -161,6 +148,7 @@ The application exposes the following REST API endpoints:
 ## Security
 
 The chart creates minimal RBAC permissions:
+
 - List pods in the target namespace
 - Read pod logs in the target namespace
 
@@ -169,11 +157,13 @@ API key authentication is optional but recommended when exposing the ingress.
 ## Storage Considerations
 
 ### EmptyDir (Default)
+
 - Logs are stored in the pod's ephemeral storage
 - Data is lost when the pod is deleted or restarted
 - Suitable for development or when log persistence is not required
 
 ### Persistent Volume
+
 - Logs are stored on persistent storage
 - Data survives pod restarts and deletions
 

--- a/src/index.html
+++ b/src/index.html
@@ -152,10 +152,15 @@
                 <div class="sm:col-span-2">
                     <label for="searchBox" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Search <a href="#" id="clearSearch" class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 text-xs">(Clear)</a></label>
                     <div class="mt-1 relative">
-                        <input type="text" id="searchBox" placeholder="Enter to search..." title="Search searches all available logs, not just the current page. Results are then limited by Lines per Page setting." class="block w-full py-2 px-3 pr-12 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
-                        <button id="caseSensitiveToggle" class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none" title="Toggle case sensitivity">
-                            <span class="text-sm font-mono">Aa</span>
-                        </button>
+                        <input type="text" id="searchBox" placeholder="Enter to search..." title="Search searches all available logs, not just the current page. Results are then limited by Lines per Page setting." class="block w-full py-2 px-3 pr-24 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                        <div class="absolute inset-y-0 right-0 pr-3 flex items-center space-x-2">
+                            <button id="highlightToggle" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none" title="Toggle search term highlighting">
+                                <span class="text-sm font-mono">H</span>
+                            </button>
+                            <button id="caseSensitiveToggle" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none" title="Toggle case sensitivity">
+                                <span class="text-sm font-mono">Aa</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -218,10 +223,12 @@
             const storageStatsContent = document.getElementById('storageStatsContent');
             const appVersion = document.getElementById('appVersion');
             const caseSensitiveToggle = document.getElementById('caseSensitiveToggle');
+            const highlightToggle = document.getElementById('highlightToggle');
 
             let currentLogs = [];
             let currentPodName = null;
-            let caseSensitive = false;
+            let caseSensitive = localStorage.getItem('caseSensitive') === 'true';
+            let highlightEnabled = localStorage.getItem('highlightEnabled') !== 'false'; // Default to true if not set
 
             // --- Version Information ---
             async function fetchVersion() {
@@ -385,16 +392,40 @@
                 }
             };
 
+            // --- Highlight Toggle ---
+            const updateHighlightDisplay = () => {
+                if (highlightEnabled) {
+                    highlightToggle.classList.remove('text-gray-400');
+                    highlightToggle.classList.add('text-indigo-600', 'dark:text-indigo-400');
+                    highlightToggle.title = 'Search term highlighting enabled (click to toggle)';
+                } else {
+                    highlightToggle.classList.remove('text-indigo-600', 'dark:text-indigo-400');
+                    highlightToggle.classList.add('text-gray-400');
+                    highlightToggle.title = 'Search term highlighting disabled (click to toggle)';
+                }
+            };
+
             caseSensitiveToggle.addEventListener('click', (event) => {
                 event.preventDefault();
                 caseSensitive = !caseSensitive;
+                localStorage.setItem('caseSensitive', caseSensitive.toString());
                 updateCaseSensitiveDisplay();
                 if (searchBox.value.trim()) {
                     fetchAndDisplayLogs();
                 }
             });
 
+            highlightToggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                highlightEnabled = !highlightEnabled;
+                localStorage.setItem('highlightEnabled', highlightEnabled.toString());
+                updateHighlightDisplay();
+                renderLogs(); // Just re-render the logs since we don't need to fetch again
+            });
+
+            // Initialize display states
             updateCaseSensitiveDisplay();
+            updateHighlightDisplay();
 
             // --- API Calls ---
             async function fetchFromServer(endpoint, options = {}) {
@@ -692,7 +723,7 @@
                     }
 
                     // Apply search highlighting on the potentially colorized message
-                    if (searchTerm) {
+                    if (searchTerm && highlightEnabled) {
                         const searchFlags = caseSensitive ? 'g' : 'gi';
                         const searchRegex = new RegExp(`(${escapeRegExp(searchTerm)})`, searchFlags);
                         coloredMessageContent = coloredMessageContent.replace(searchRegex, (match, p1) => {

--- a/src/index.html
+++ b/src/index.html
@@ -151,7 +151,12 @@
 
                 <div class="sm:col-span-2">
                     <label for="searchBox" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Search <a href="#" id="clearSearch" class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 text-xs">(Clear)</a></label>
-                    <input type="text" id="searchBox" placeholder="Enter to search..." class="mt-1 block w-full py-2 px-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                    <div class="mt-1 relative">
+                        <input type="text" id="searchBox" placeholder="Enter to search..." title="Search searches all available logs, not just the current page. Results are then limited by Lines per Page setting." class="block w-full py-2 px-3 pr-12 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                        <button id="caseSensitiveToggle" class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none" title="Toggle case sensitivity">
+                            <span class="text-sm font-mono">Aa</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div id="namespaceDisplay" class="mt-3 text-xs text-gray-500 dark:text-gray-400">Namespace: <span id="namespaceValue">Loading...</span></div>
@@ -212,9 +217,11 @@
             const closeStorageStats = document.getElementById('closeStorageStats');
             const storageStatsContent = document.getElementById('storageStatsContent');
             const appVersion = document.getElementById('appVersion');
+            const caseSensitiveToggle = document.getElementById('caseSensitiveToggle');
 
             let currentLogs = [];
             let currentPodName = null;
+            let caseSensitive = false;
 
             // --- Version Information ---
             async function fetchVersion() {
@@ -364,6 +371,30 @@
             });
 
             applyTheme();
+
+            // --- Case Sensitivity Toggle ---
+            const updateCaseSensitiveDisplay = () => {
+                if (caseSensitive) {
+                    caseSensitiveToggle.classList.remove('text-gray-400');
+                    caseSensitiveToggle.classList.add('text-indigo-600', 'dark:text-indigo-400');
+                    caseSensitiveToggle.title = 'Case sensitive search (click to toggle)';
+                } else {
+                    caseSensitiveToggle.classList.remove('text-indigo-600', 'dark:text-indigo-400');
+                    caseSensitiveToggle.classList.add('text-gray-400');
+                    caseSensitiveToggle.title = 'Case insensitive search (click to toggle)';
+                }
+            };
+
+            caseSensitiveToggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                caseSensitive = !caseSensitive;
+                updateCaseSensitiveDisplay();
+                if (searchBox.value.trim()) {
+                    fetchAndDisplayLogs();
+                }
+            });
+
+            updateCaseSensitiveDisplay();
 
             // --- API Calls ---
             async function fetchFromServer(endpoint, options = {}) {
@@ -524,6 +555,7 @@
                     sort_order: sortOrder.value,
                     tail_lines: numLines.value,
                     search_string: searchBox.value.trim(),
+                    case_sensitive: caseSensitive.toString(),
                 });
 
                 // Add exclude_self parameter if needed
@@ -661,7 +693,8 @@
 
                     // Apply search highlighting on the potentially colorized message
                     if (searchTerm) {
-                        const searchRegex = new RegExp(`(${escapeRegExp(searchTerm)})`, 'gi');
+                        const searchFlags = caseSensitive ? 'g' : 'gi';
+                        const searchRegex = new RegExp(`(${escapeRegExp(searchTerm)})`, searchFlags);
                         coloredMessageContent = coloredMessageContent.replace(searchRegex, (match, p1) => {
                             const tempDiv = document.createElement('div');
                             tempDiv.innerHTML = coloredMessageContent;


### PR DESCRIPTION
## Summary
- Add case sensitivity toggle (Aa button) to search UI with visual feedback
- Add case_sensitive API parameter to /api/logs and /api/archived_logs endpoints  
- Search now searches entire log history, not just current page window
- When searching, fetch all logs first, then filter by search term, then apply pagination
- Case-insensitive search remains the default behavior

## Key Features
- **Case Sensitivity Toggle**: Click the "Aa" button next to search box to toggle between case-sensitive and case-insensitive search
- **Full Log Search**: Search now looks through entire log history, not limited by "Lines per Page" setting
- **Smart Pagination**: Search results are then limited by the "Lines per Page" setting after filtering
- **Visual Feedback**: Aa button changes color (gray = case-insensitive, blue = case-sensitive)
- **Helpful Tooltips**: Search box tooltip explains the enhanced behavior

## API Changes
- Added `case_sensitive` parameter to `/api/logs` and `/api/archived_logs` endpoints
- When `search_string` is provided, API now fetches all logs first, then filters, then applies `tail_lines`
- Backwards compatible - new parameter is optional and defaults to case-insensitive

## Test plan
- [x] Verify case-sensitive and case-insensitive search work correctly
- [x] Verify search finds results across entire log history
- [x] Verify pagination still works correctly after search filtering
- [x] Verify UI toggle provides visual feedback
- [x] Verify API backwards compatibility
- [x] Code quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)